### PR TITLE
Update detect-browser to 4.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-- 0.10.29
+- 6
+- lts/*
 
 env:
   matrix:
@@ -27,5 +28,5 @@ before_install:
 
 notifications:
   email:
-  - damon.oehlman@nicta.com.au
+  - nathan.oehlman@coviu.com
   irc: irc.freenode.org#rtc.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ matrix:
     - env: BROWSER=chrome  BVER=unstable
     - env: BROWSER=firefox BVER=nightly
 
-before_install:
-  - mkdir -p .travis
-  - curl -s https://codeload.github.com/rtc-io/webrtc-testing-on-travis/tar.gz/master | tar -xz --strip-components=1 --directory .travis
-  - ./.travis/setup.sh
+before_script:
+  - ./node_modules/travis-multirunner/setup.sh
   - export DISPLAY=:99.0
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+  - sh -e /etc/init.d/xvfb start
+
+after_failure:
+  - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+services:
+  - xvfb
 language: node_js
 node_js:
 - 6
@@ -24,8 +26,6 @@ matrix:
 
 before_script:
   - ./node_modules/travis-multirunner/setup.sh
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+sudo: false
 language: node_js
 node_js:
 - 6
 - lts/*
 
 env:
+  global:
+    - CXX=g++-4.8
   matrix:
   - BROWSER=chrome  BVER=stable
   - BROWSER=chrome  BVER=beta
@@ -31,3 +34,10 @@ notifications:
   email:
   - nathan.oehlman@coviu.com
   irc: irc.freenode.org#rtc.io
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/detect.js
+++ b/detect.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-var browser = require('detect-browser');
+var browser = require('detect-browser').detect();
 
 /**
   ### `rtc-core/detect`

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
     "detect-browser": "^4.6.0"
   },
   "devDependencies": {
+    "broth": "^2.1.1",
+    "browserify": "^11.0.0",
     "freeice": "^2.1.0",
     "peerpair": "^1.0.0",
-    "tape": "^2",
-    "testling": "^1.7.0"
+    "tap-spec": "^4.0.2",
+    "travis-multirunner": "^4.5.0"
   },
   "scripts": {
     "gendocs": "gendocs > README.md",
-    "test": "testling -x ./.travis/start-$BROWSER.sh"
+    "test": "browserify test/all.js | broth start | tap-spec"
   },
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "freeice": "^2.1.0",
     "peerpair": "^1.0.0",
     "tap-spec": "^4.0.2",
+    "tape": "^2",
     "travis-multirunner": "^4.5.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Core definitions and functions for the rtc.io suite",
   "version": "4.0.0",
   "dependencies": {
-    "detect-browser": "^1.0.0"
+    "detect-browser": "^4.6.0"
   },
   "devDependencies": {
     "freeice": "^2.1.0",


### PR DESCRIPTION
This updates the `detect-browser` package version to 4.6.0.

This is in order to correctly detect the version of Safari on PC - previously the `1.x` branch of detect-browser would incorrectly return the WebKit version of Safari, instead of the Safari version itself.