### PR TITLE
Add `detect.os` property

### DIFF
--- a/detect.js
+++ b/detect.js
@@ -73,3 +73,4 @@ detect.moz = typeof navigator != 'undefined' && !!navigator.mozGetUserMedia;
 // set the browser and browser version
 detect.browser = browser.name;
 detect.browserVersion = detect.version = browser.version;
+detect.os = browser.os;


### PR DESCRIPTION
This PR adds `detect.os` property that to allow to detect the operating system of the browser